### PR TITLE
Provide hook "after delete expired item".

### DIFF
--- a/includes/class-woocommerce-cart-stock-reducer.php
+++ b/includes/class-woocommerce-cart-stock-reducer.php
@@ -112,8 +112,8 @@ class WC_Cart_Stock_Reducer extends WC_Integration {
 		if ( 'yes' === $this->expire_items ) {
 			$expired_cart_notice = apply_filters( 'wc_csr_expired_cart_notice', sprintf( __( "Sorry, '%s' was removed from your cart because you didn't checkout before the expiration time.", 'woocommerce-cart-stock-reducer' ), $cart->cart_contents[ $cart_id ][ 'data' ]->get_title() ), $cart_id, $cart );
 			wc_add_notice( $expired_cart_notice, 'error' );
+			do_action( 'wc_csr_before_remove_expired_item', $cart_id, $cart );
 			unset( $cart->cart_contents[ $cart_id ] );
-			do_action( 'wc_csr_after_removed_expired_item' );
 		}
 
 	}

--- a/includes/class-woocommerce-cart-stock-reducer.php
+++ b/includes/class-woocommerce-cart-stock-reducer.php
@@ -113,6 +113,7 @@ class WC_Cart_Stock_Reducer extends WC_Integration {
 			$expired_cart_notice = apply_filters( 'wc_csr_expired_cart_notice', sprintf( __( "Sorry, '%s' was removed from your cart because you didn't checkout before the expiration time.", 'woocommerce-cart-stock-reducer' ), $cart->cart_contents[ $cart_id ][ 'data' ]->get_title() ), $cart_id, $cart );
 			wc_add_notice( $expired_cart_notice, 'error' );
 			unset( $cart->cart_contents[ $cart_id ] );
+			do_action( 'wc_csr_after_removed_expired_item' );
 		}
 
 	}


### PR DESCRIPTION
Please consider to merge the pull request and release a new version of the plugin, so that we have to possibility to hook into this part of the code to purge the server side cache after item is expired from cart, thank you.
